### PR TITLE
fix: replace datasource id with variable id

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -41,7 +51,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -101,7 +111,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -122,7 +132,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -182,7 +192,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -204,7 +214,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -303,7 +313,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -319,7 +329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -337,7 +347,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -460,7 +470,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -477,7 +487,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -533,7 +543,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -557,7 +567,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -641,7 +651,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -663,7 +673,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -723,7 +733,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -745,7 +755,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -829,7 +839,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -851,7 +861,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -898,7 +908,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -919,7 +929,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -965,7 +975,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -984,7 +994,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1003,7 +1013,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1070,7 +1080,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1089,7 +1099,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1172,7 +1182,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1190,7 +1200,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1273,7 +1283,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1291,7 +1301,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1355,7 +1365,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1377,7 +1387,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1444,7 +1454,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1463,7 +1473,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1516,7 +1526,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "max(minio_heal_time_last_activity_nano_seconds{job=~\"$scrape_jobs\"})",
@@ -1536,7 +1546,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1589,7 +1599,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "max(minio_usage_last_activity_nano_seconds{job=~\"$scrape_jobs\"})",
@@ -1609,7 +1619,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1724,7 +1734,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1742,7 +1752,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1857,7 +1867,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1875,7 +1885,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1990,7 +2000,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2008,7 +2018,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2064,7 +2074,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2081,7 +2091,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2098,7 +2108,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2115,7 +2125,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2132,7 +2142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2153,7 +2163,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2214,7 +2224,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -2233,7 +2243,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2317,7 +2327,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2331,7 +2341,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2348,7 +2358,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2401,7 +2411,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2418,7 +2428,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of bytes received and sent on MinIO cluster",
       "fieldConfig": {
@@ -2502,7 +2512,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2519,7 +2529,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2536,7 +2546,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -2654,7 +2664,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2671,7 +2681,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of online drives per MinIO Server",
       "fieldConfig": {
@@ -2790,7 +2800,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2807,7 +2817,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2824,7 +2834,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2909,7 +2919,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2926,7 +2936,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3011,7 +3021,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -3028,7 +3038,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3113,7 +3123,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -3130,7 +3140,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3190,7 +3200,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "minio_cluster_kms_uptime{job=~\"$scrape_jobs\"}",
@@ -3210,7 +3220,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3325,7 +3335,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by (server) (increase(minio_cluster_kms_request_error{job=~\"$scrape_jobs\"}[$__rate_interval]))",
@@ -3341,7 +3351,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3426,7 +3436,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by (server) (minio_cluster_kms_online{job=~\"$scrape_jobs\"})",
@@ -3441,7 +3451,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3526,7 +3536,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -3543,7 +3553,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3658,7 +3668,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by (server) (increase(minio_cluster_kms_request_failure{job=~\"$scrape_jobs\"}[$__rate_interval]))",
@@ -3674,7 +3684,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3789,7 +3799,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "sum by (server) (rate(minio_cluster_kms_request_success{job=~\"$scrape_jobs\"}[$__rate_interval]))",
@@ -3805,7 +3815,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "defwbesk6ww00b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3890,7 +3900,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "defwbesk6ww00b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -3924,7 +3934,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "defwbesk6ww00b"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(job)",
         "includeAll": true,


### PR DESCRIPTION
Previously the dashboard JSON was exported with a Prometheus Datasource ID hardcoded into it, but now a variable datasource is used.

The user in now asked to select a Prometheus datasource when importing the dashboard but don't allow to change the datasource later without importing the dashboard again.

Resolve #1
